### PR TITLE
Add pyproject.toml to enable standard packaging and installation (pipx/uv)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+  requires = ["setuptools>=68", "wheel"]
+  build-backend = "setuptools.build_meta"
+
+[project]
+  name = "winrmexec"
+  version = "1.0.0"
+  requires-python = ">=3.8"
+  description = "Impacket-only implementation of WinRM protocol with support for NTLM and Kerberos auth"
+  readme = "README.md"
+  authors = [{ name = "ozelis", email = "example@example.com" }]
+  license = { text = "MIT" }
+  keywords = [
+    "winrm",
+    "impacket",
+    "ntlm",
+    "kerberos",
+    "security",
+    "redteam"
+  ]
+  classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Information Technology",
+    "Topic :: Security",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8"
+  ]
+  dependencies = [
+    "impacket>=0.13.0",
+    "requests>=2.30.0",
+    "prompt_toolkit>=3.0.0",
+    "requests-ntlm>=1.2.0",
+    "requests-kerberos>=0.14.0",
+    "pyreadline3; platform_system == 'Windows'"
+  ]
+
+[project.urls]
+  Homepage = "https://github.com/ozelis/winrmexec"
+  Source = "https://github.com/ozelis/winrmexec"
+
+[project.scripts]
+  winrmexec = "winrmexec:main"
+  evil-winrmexec = "evil_winrmexec:main"
+
+[tool.setuptools]
+  py-modules = [
+    "winrmexec",
+    "evil_winrmexec"
+  ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,15 @@
   ]
   dependencies = [
     "impacket>=0.13.0",
-    "requests>=2.30.0",
+    "requests>=2.30.0"
+  ]
+
+[project.optional-dependencies]
+  interactive = [
     "prompt_toolkit>=3.0.0",
     "requests-ntlm>=1.2.0",
-    "requests-kerberos>=0.14.0",
-    "pyreadline3; platform_system == 'Windows'"
-  ]
+    "requests-kerberos>=0.14.0"
+]
 
 [project.urls]
   Homepage = "https://github.com/ozelis/winrmexec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,15 +28,9 @@
   ]
   dependencies = [
     "impacket>=0.13.0",
-    "requests>=2.30.0"
+    "requests>=2.30.0",
+    "prompt_toolkit>=3.0.0"
   ]
-
-[project.optional-dependencies]
-  interactive = [
-    "prompt_toolkit>=3.0.0",
-    "requests-ntlm>=1.2.0",
-    "requests-kerberos>=0.14.0"
-]
 
 [project.urls]
   Homepage = "https://github.com/ozelis/winrmexec"


### PR DESCRIPTION
## Description

This PR adds a standard `pyproject.toml` file to the repository.  
Currently, users need to clone the repo and manage dependencies manually. 
By adding packaging metadata, the tools can be easily installed into isolated environments, with dependencies (`impacket`, `requests`, `prompt_toolkit` etc) resolved automatically.

This makes usage with modern tool managers like `uv` or `pipx` much smoother and exposes the scripts (e.g., `winrmexec`, `evil-winrmexec`) directly to the PATH.

## How to test / Install

### 1. Local Installation (Testing this PR)

You can test the installation directly from the source directory:

**Using uv (Recommended):**

```sh
uv tool install .
```

**Using pipx:**

```sh
pipx install .
  installed package winrmexec 1.0.0, installed using Python 3.13.12
  These apps are now available
    - evil-winrmexec
    - winrmexec
done! ✨ 🌟 ✨
```

```sh
## Verify:

$ winrmexec -h
Impacket v0.13.0 - Copyright Fortra, LLC and its affiliated companies 

usage: winrmexec [-h] [-ts] [-debug] [-dc-ip DC_IP] [-target-ip TARGET_IP] [-port PORT] [-ssl] [-url URL] [-spn SPN]
                 [-hashes LMHASH:NTHASH] [-no-pass] [-k] [-aesKey HEXKEY] [-basic] [-cert-pem CERT_PEM]
                 [-cert-key CERT_KEY] [-credssp] [-X COMMAND] [-timeout SECONDS]
                 target

positional arguments:
  target                [[domain/]username[:password]@]<target>

options:
  -h, --help            show this help message and exit
  -ts                   adds timestamp to every logging output
  -debug                Turn DEBUG output ON
  -X COMMAND            Command to execute, if ommited it will spawn a janky interactive shell
  -timeout SECONDS      Timeout for requests to /wsman

connection:
  -dc-ip DC_IP          IP Address of the domain controller. If omitted it will use the domain part (FQDN) specified in
                        the target parameter
  -target-ip TARGET_IP  IP Address of the target machine. If ommited it will use whatever was specified as target. This
                        is useful when target is the NetBIOSname and you cannot resolve it
  -port PORT            Destination port to connect to WinRM http server, default is 5985
  -ssl                  Use HTTPS
  -url URL              Exact WSMan endpoint, eg. http://host:port/custom_wsman. Otherwise it will be constructed as
                        http(s)://target_ip:port/wsman

authentication:
  -spn SPN              Specify exactly the SPN to request for TGS
  -hashes LMHASH:NTHASH
                        NTLM hashes, format is LMHASH:NTHASH
  -no-pass              don't ask for password (useful for -k)
  -k                    Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME)based on target
                        parameters. If valid credentials cannot be found, it will use the ones specified in the command
                        line
  -aesKey HEXKEY        AES key to use for Kerberos Authentication
  -basic                Use Basic auth
  -cert-pem CERT_PEM    Client certificate
  -cert-key CERT_KEY    Client certificate private key
  -credssp              Use CredSSP if enabled, works with NTLM and Kerberos but it needs plaintext password either way
```

```sh
## Verify:

$ evil-winrmexec -h
usage: evil-winrmexec [-h] [-ts] [-debug] [-dc-ip DC_IP] [-target-ip TARGET_IP] [-port PORT] [-ssl] [-url URL] [-spn SPN]
                      [-hashes LMHASH:NTHASH] [-no-pass] [-k] [-aesKey HEXKEY] [-basic] [-cert-pem CERT_PEM]
                      [-cert-key CERT_KEY] [-credssp] [-X COMMAND] [-timeout SECONDS]
                      target

positional arguments:
  target                [[domain/]username[:password]@]<target>

options:
  -h, --help            show this help message and exit
  -ts                   adds timestamp to every logging output
  -debug                Turn DEBUG output ON
  -X COMMAND            Command to execute, if ommited it will spawn a janky interactive shell
  -timeout SECONDS      Timeout for requests to /wsman

connection:
  -dc-ip DC_IP          IP Address of the domain controller. If omitted it will use the domain part (FQDN) specified in
                        the target parameter
  -target-ip TARGET_IP  IP Address of the target machine. If ommited it will use whatever was specified as target. This
                        is useful when target is the NetBIOSname and you cannot resolve it
  -port PORT            Destination port to connect to WinRM http server, default is 5985
  -ssl                  Use HTTPS
  -url URL              Exact WSMan endpoint, eg. http://host:port/custom_wsman. Otherwise it will be constructed as
                        http(s)://target_ip:port/wsman

authentication:
  -spn SPN              Specify exactly the SPN to request for TGS
  -hashes LMHASH:NTHASH
                        NTLM hashes, format is LMHASH:NTHASH
  -no-pass              don't ask for password (useful for -k)
  -k                    Use Kerberos authentication. Grabs credentials from ccache file (KRB5CCNAME)based on target
                        parameters. If valid credentials cannot be found, it will use the ones specified in the command
                        line
  -aesKey HEXKEY        AES key to use for Kerberos Authentication
  -basic                Use Basic auth
  -cert-pem CERT_PEM    Client certificate
  -cert-key CERT_KEY    Client certificate private key
  -credssp              Use CredSSP if enabled, works with NTLM and Kerberos but it needs plaintext password either way
```

### 2. Remote Installation (After Merge)

Once merged, users can install the tools directly from GitHub without manual cloning:

**Using uv:**

```sh
uv tool install git+https://github.com/ozelis/winrmexec
```

**Using pipx:**

```sh
pipx install git+https://github.com/ozelis/winrmexec
```
